### PR TITLE
chore: rename script/command to scale for easier cli use

### DIFF
--- a/gnome-text-scaling-factor/install.sh
+++ b/gnome-text-scaling-factor/install.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-chmod +x ./text-scaling-factor
-sudo cp ./text-scaling-factor /usr/bin/
+chmod +x ./scale
+sudo cp ./scale /usr/bin/
 exit_code=$?
 if [ $exit_code -eq 0 ]; then
   echo "Successfully installed text-scaling-factor."
+  echo "You can now use it as 'scale up|down'"
 else
   echo "Something went wrong... Please try again. exit_code: $exit_code"
   exit $exit_code 

--- a/gnome-text-scaling-factor/scale
+++ b/gnome-text-scaling-factor/scale
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function print_help {
-    printf "text-scaling-factor(.sh)\n\n"
+    printf "scale(.sh)\n\n"
     printf "\thelp\tThis output\n"
     printf "\tup\tChanges factor to 1.5\n"
     printf "\tdown\tChanges factor to 1.0\n"


### PR DESCRIPTION
Rename the _gnome-text-scaling-factor_ script to _scale_ for easier cli usage.